### PR TITLE
Add accessible students filter

### DIFF
--- a/Epsilon.Abstractions/Services/IFilterService.cs
+++ b/Epsilon.Abstractions/Services/IFilterService.cs
@@ -1,8 +1,11 @@
+using Epsilon.Canvas.Abstractions.GraphQl;
 using Epsilon.Canvas.Abstractions.Rest;
 
 namespace Epsilon.Abstractions.Services;
 
 public interface IFilterService
 {
-    Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms();
+    Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms(string studentId);
+
+    Task<IEnumerable<User>> GetAccessibleStudents();
 }

--- a/Epsilon.Canvas.Abstractions/CanvasUserSession.cs
+++ b/Epsilon.Canvas.Abstractions/CanvasUserSession.cs
@@ -4,10 +4,10 @@ namespace Epsilon.Canvas.Abstractions;
 /// Canvas user session model which holds necessary information to keep track of a Canvas user. Still prone to change.
 /// </summary>
 /// <param name="CourseId">Canvas personal course id</param>
-/// <param name="StudentId">Canvas student id</param>
+/// <param name="UserId">Canvas user id</param>
 /// <param name="AccessToken">Canvas access token</param>
 public record CanvasUserSession(
     int CourseId,
-    int StudentId,
+    int UserId,
     string AccessToken
 );

--- a/Epsilon.Canvas.Abstractions/GraphQl/Course.cs
+++ b/Epsilon.Canvas.Abstractions/GraphQl/Course.cs
@@ -4,5 +4,6 @@ namespace Epsilon.Canvas.Abstractions.GraphQl;
 
 public record Course(
     [property: JsonPropertyName("name")] string? Name,
-    [property: JsonPropertyName("submissionsConnection")] GraphQlConnection<Submission>? Submissions
+    [property: JsonPropertyName("submissionsConnection")] GraphQlConnection<Submission>? Submissions,
+    [property: JsonPropertyName("enrollmentsConnection")] GraphQlConnection<Enrollment>? Enrollments
 );

--- a/Epsilon.Canvas.Abstractions/GraphQl/Enrollment.cs
+++ b/Epsilon.Canvas.Abstractions/GraphQl/Enrollment.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Epsilon.Canvas.Abstractions.GraphQl;
+
+public record Enrollment(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("user")] User User
+);

--- a/Epsilon.Canvas.Abstractions/GraphQl/User.cs
+++ b/Epsilon.Canvas.Abstractions/GraphQl/User.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Epsilon.Canvas.Abstractions.GraphQl;
+
+public record User(
+    [property: JsonPropertyName("_id")] string? LegacyId,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("avatarUrl")] Uri? AvatarUrl
+);

--- a/Epsilon.Host.Frontend/src/api.ts
+++ b/Epsilon.Host.Frontend/src/api.ts
@@ -45,6 +45,13 @@ export interface PageUpdateRequest {
     body: string
 }
 
+export interface User {
+    _id?: string | null
+    name?: string | null
+    /** @format uri */
+    avatarUrl?: string | null
+}
+
 export type QueryParamsType = Record<string | number, any>
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">
 
@@ -347,9 +354,30 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
          * @name ParticipatedTermsList
          * @request GET:/Filter/participated-terms
          */
-        participatedTermsList: (params: RequestParams = {}) =>
+        participatedTermsList: (
+            query?: {
+                studentId?: string
+            },
+            params: RequestParams = {}
+        ) =>
             this.request<EnrollmentTerm[], any>({
                 path: `/Filter/participated-terms`,
+                method: "GET",
+                query: query,
+                format: "json",
+                ...params,
+            }),
+
+        /**
+         * No description
+         *
+         * @tags Filter
+         * @name AccessibleStudentsList
+         * @request GET:/Filter/accessible-students
+         */
+        accessibleStudentsList: (params: RequestParams = {}) =>
+            this.request<User[], any>({
+                path: `/Filter/accessible-students`,
                 method: "GET",
                 format: "json",
                 ...params,

--- a/Epsilon.Host.Frontend/src/components/Header.vue
+++ b/Epsilon.Host.Frontend/src/components/Header.vue
@@ -4,8 +4,12 @@
         <Row>
             <Col :cols="9">
                 <div class="d-flex">
-                    <img :src="DefaultAvatar" class="avatar-image" alt="test" />
-                    <SearchBox v-model="undefined" :items="[]" :limit="5" />
+                    <img :src="avatarImage" class="avatar-image" alt="test" />
+                    <SearchBox
+                        v-model="selectedStudent"
+                        :items="students"
+                        placeholder="Student"
+                        :limit="5" />
                 </div>
             </Col>
             <Col :cols="3">
@@ -25,21 +29,48 @@ import SearchBox from "@/components/SearchBox.vue"
 import Row from "@/components/Row.vue"
 import Col from "@/components/Col.vue"
 
-import { inject, onMounted, Ref, ref } from "vue"
-import { Api, EnrollmentTerm, HttpResponse } from "@/api"
+import { computed, inject, onMounted, Ref, ref, watch } from "vue"
+import { Api, EnrollmentTerm, HttpResponse, User } from "@/api"
 
 const api = inject<Api<unknown>>("api")
+
+const students: Ref<User[]> = ref([])
+const selectedStudent: Ref<User | undefined> = ref(undefined)
 
 const terms: Ref<EnrollmentTerm[]> = ref([])
 const selectedTerm: Ref<EnrollmentTerm | undefined> = ref(undefined)
 
 onMounted(() => {
+    api?.filter.accessibleStudentsList().then((r: HttpResponse<User[]>) => {
+        students.value = r.data
+        selectedStudent.value = students.value[0]
+    })
+})
+
+watch(selectedStudent, () => {
+    if (!selectedStudent.value?._id) {
+        return
+    }
+
+    // Reset current term list
+    terms.value = []
+
     api?.filter
-        .participatedTermsList()
+        .participatedTermsList({
+            studentId: selectedStudent.value?._id,
+        })
         .then((r: HttpResponse<EnrollmentTerm[]>) => {
             terms.value = r.data
             selectedTerm.value = terms.value[0]
         })
+})
+
+const avatarImage = computed(() => {
+    if (!selectedStudent.value?.avatarUrl) {
+        return DefaultAvatar
+    }
+
+    return selectedStudent.value?.avatarUrl
 })
 </script>
 

--- a/Epsilon.Host.Frontend/src/components/Header.vue
+++ b/Epsilon.Host.Frontend/src/components/Header.vue
@@ -5,17 +5,15 @@
             <Col :cols="9">
                 <div class="d-flex">
                     <img :src="DefaultAvatar" class="avatar-image" alt="test" />
-                    <SearchBox
-                        v-model="undefined"
-                        :items="[]"
-                        placeholder="Student" />
+                    <SearchBox v-model="undefined" :items="[]" :limit="5" />
                 </div>
             </Col>
             <Col :cols="3">
                 <SearchBox
                     v-model="selectedTerm"
                     :items="terms"
-                    placeholder="Term" />
+                    placeholder="Term"
+                    :limit="10" />
             </Col>
         </Row>
     </div>

--- a/Epsilon.Host.Frontend/src/components/SearchBox.vue
+++ b/Epsilon.Host.Frontend/src/components/SearchBox.vue
@@ -54,6 +54,7 @@ const props = defineProps<{
     items: Array<{ name?: string | null }>
     modelValue: { name: string }
     placeholder?: string
+    limit: number
 }>()
 
 const query = ref("")
@@ -62,19 +63,21 @@ defineEmits(["update:modelValue"])
 
 const filteredItems = computed(() => {
     if (query.value === "") {
-        return props.items
+        return props.items.slice(0, props.limit)
     }
 
-    return props.items.filter((item) => {
-        if (!item.name) {
-            return false
-        }
+    return props.items
+        .filter((item) => {
+            if (!item.name) {
+                return false
+            }
 
-        return item.name
-            .toLowerCase()
-            .replace(/\s+/g, "")
-            .includes(query.value.toLowerCase().replace(/\s+/g, ""))
-    })
+            return item.name
+                .toLowerCase()
+                .replace(/\s+/g, "")
+                .includes(query.value.toLowerCase().replace(/\s+/g, ""))
+        })
+        .slice(0, props.limit)
 })
 
 function displayValue(item: { name: string }): string {

--- a/Epsilon.Host.WebApi/Controllers/FilterController.cs
+++ b/Epsilon.Host.WebApi/Controllers/FilterController.cs
@@ -16,8 +16,8 @@ public class FilterController : Controller
     }
 
     [HttpGet("participated-terms")]
-    public async Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms()
+    public async Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms(string studentId)
     {
-        return await _filterService.GetParticipatedTerms();
+        return await _filterService.GetParticipatedTerms(studentId);
     }
 }

--- a/Epsilon.Host.WebApi/Controllers/FilterController.cs
+++ b/Epsilon.Host.WebApi/Controllers/FilterController.cs
@@ -1,4 +1,5 @@
 using Epsilon.Abstractions.Services;
+using Epsilon.Canvas.Abstractions.GraphQl;
 using Epsilon.Canvas.Abstractions.Rest;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,5 +20,11 @@ public class FilterController : Controller
     public async Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms(string studentId)
     {
         return await _filterService.GetParticipatedTerms(studentId);
+    }
+    
+    [HttpGet("accessible-students")]
+    public async Task<IEnumerable<User>> GetAccessibleStudents()
+    {
+        return await _filterService.GetAccessibleStudents();
     }
 }

--- a/Epsilon.Host.WebApi/Options/CanvasMockOptions.cs
+++ b/Epsilon.Host.WebApi/Options/CanvasMockOptions.cs
@@ -15,7 +15,7 @@ public class CanvasMockOptions
     public int CourseId { get; set; }
 
     [Required]
-    public int StudentId { get; set; }
+    public int UserId { get; set; }
 
     [Required(AllowEmptyStrings = false)]
     public string AccessToken { get; set; } = string.Empty;

--- a/Epsilon/Services/FilterService.cs
+++ b/Epsilon/Services/FilterService.cs
@@ -30,11 +30,11 @@ public class FilterService : IFilterService
         _canvasRest = canvasRest;
     }
 
-    public async Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms()
+    public async Task<IEnumerable<EnrollmentTerm>> GetParticipatedTerms(string studentId)
     {
         var allTerms = await _canvasRest.Accounts.GetTerms(1);
 
-        var variables = new Dictionary<string, object> { { "$studentIds", _canvasUser.StudentId }, };
+        var variables = new Dictionary<string, object> { { "studentIds", studentId }, };
         var response = await _canvasGraphQl.Query(ParticipatedTermQuery, variables);
 
         if (response == null)

--- a/Epsilon/Services/FilterService.cs
+++ b/Epsilon/Services/FilterService.cs
@@ -78,7 +78,7 @@ public class FilterService : IFilterService
 
         return response?.Courses!
                        .Where(c => c.Enrollments != null && c.Enrollments.Nodes.Any(e =>
-                               e.User.LegacyId == _canvasUser.StudentId.ToString(CultureInfo.InvariantCulture)
+                               e.User.LegacyId == _canvasUser.UserId.ToString(CultureInfo.InvariantCulture)
                                && e.Type == "TeacherEnrollment"
                            )
                        )


### PR DESCRIPTION
This pull request adds the accessible students filter and modifies the participated terms filter to acommodate the student selection box. The accessible students filter works by listing out all of the enrollments within all courses and returns a distinct list of the students within a course, if and only if the current user session is a teacher within that course.