### PR TITLE
Disable quick fixes in code analysis workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,6 +87,6 @@ jobs:
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:
-          args: --user,root,--apply-fixes
+          args: --user,root
           use-annotations: true
           push-fixes: pull-request


### PR DESCRIPTION
Apparently the .NET linter does not support quick fixes (thank you JetBrains for letting us know), which causes the code analysis workflow to crash. For more information: https://youtrack.jetbrains.com/issue/QD-6559.