### PR TITLE
Bug fix: issue 260 - fix new Kpi's Mastered in Epsilon Wrapped

### DIFF
--- a/Epsilon.Host.Frontend/src/api.generated.ts
+++ b/Epsilon.Host.Frontend/src/api.generated.ts
@@ -11,10 +11,11 @@
 
 export interface EnrollmentTerm {
 	name?: string | null
+	_id?: string | null
 	/** @format date-time */
-	start_at?: string | null
+	startAt?: string | null
 	/** @format date-time */
-	end_at?: string | null
+	endAt?: string | null
 }
 
 export interface LearningDomain {

--- a/Epsilon.Host.Frontend/src/components/TopNavigation.vue
+++ b/Epsilon.Host.Frontend/src/components/TopNavigation.vue
@@ -89,17 +89,17 @@ watch(selectedUser, async () => {
 
 watch(selectedTerm, () => {
 	const selectedTermUnwrapped = selectedTerm.value
-	if (!selectedTermUnwrapped?.start_at || !selectedTermUnwrapped.end_at) {
+	if (!selectedTermUnwrapped?.startAt || !selectedTermUnwrapped.endAt) {
 		return
 	}
 
 	const termsUnwrapped = terms.value
 	correctedFromDate.value = new Date(
-		termsUnwrapped[termsUnwrapped.length - 1]?.start_at!
+		termsUnwrapped[termsUnwrapped.length - 1]?.startAt!
 	)
 
-	toDate.value = new Date(selectedTermUnwrapped?.end_at)
-	fromDate.value = new Date(selectedTermUnwrapped?.start_at)
+	toDate.value = new Date(selectedTermUnwrapped?.endAt)
+	fromDate.value = new Date(selectedTermUnwrapped?.startAt)
 })
 
 watch([correctedFromDate, toDate], () => {

--- a/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
+++ b/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
@@ -24,7 +24,7 @@
 						<v-col cols="4">
 							<v-card>
 								<v-card-title>
-									{{ newMasteredKpis }}
+									{{ newMasteredKpis.length }}
 								</v-card-title>
 								<v-card-text>
 									New KPI's masterd this semester
@@ -174,23 +174,19 @@ const allOutcomesCurrentSemester = computed<LearningDomainOutcome[]>(() =>
 		)
 )
 
-const newMasteredKpis = computed<LearningDomainOutcome[]>(() =>
-	allOutcomesCurrentSemester.value
-		?.filter(
-			(o) =>
-				allOutcomesPast.value.filter(
-					(x) => x.id === o.id
-				).length === 0
-		)
-		.filter(
-			(outcome, index, self) =>
-				index ===
-				self.findIndex(
-					(t) =>
-						t.id === outcome.id
-				)
-		).length
-) 
+const newMasteredKpis = computed<LearningDomainOutcome[]>(
+	() =>
+		allOutcomesCurrentSemester.value
+			?.filter(
+				(o) =>
+					allOutcomesPast.value.filter((x) => x.id === o.id)
+						.length === 0
+			)
+			.filter(
+				(outcome, index, self) =>
+					index === self.findIndex((t) => t.id === outcome.id)
+			)
+)
 
 const mostUsedDomains = computed<
 	{

--- a/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
+++ b/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
@@ -24,7 +24,23 @@
 						<v-col cols="4">
 							<v-card>
 								<v-card-title>
-									{{ newMasteredKpis?.length }}
+									{{
+										allOutcomesCurrentSemester
+											?.filter(
+												(o) =>
+													allOutcomesPast.filter(
+														(x) => x.id === o.id
+													).length === 0
+											)
+											.filter(
+												(outcome, index, self) =>
+													index ===
+													self.findIndex(
+														(t) =>
+															t.id === outcome.id
+													)
+											).length
+									}}
 								</v-card-title>
 								<v-card-text>
 									New KPI's masterd this semester
@@ -173,22 +189,6 @@ const allOutcomesCurrentSemester = computed<LearningDomainOutcome[]>(() =>
 			submission.results!.map((result) => result.outcome!)
 		)
 )
-
-const uniqueOutcomeIds = new Set<number | undefined>()
-
-const newMasteredKpis = allOutcomesCurrentSemester?.value.filter((o) => {
-	console.log("O: " + o.id)
-	if (uniqueOutcomeIds.has(o.id)) {
-		return false
-	}
-	uniqueOutcomeIds.add(o.id)
-	return true
-	allOutcomesPast.value
-		.filter((x) => x.id == o.id)
-		.forEach((x) => {
-			console.log("X: " + x.id)
-		})
-})
 
 const mostUsedDomains = computed<
 	{

--- a/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
+++ b/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
@@ -24,9 +24,7 @@
 						<v-col cols="4">
 							<v-card>
 								<v-card-title>
-									{{
-										newMasteredKpis?.length
-									}}
+									{{ newMasteredKpis?.length }}
 								</v-card-title>
 								<v-card-text>
 									New KPI's masterd this semester
@@ -136,7 +134,7 @@ const term = computed<EnrollmentTerm | undefined>(() => props.terms?.at(0))
 const showWrapped = computed<boolean>(() => {
 	if (term.value != undefined) {
 		return (
-			(new Date(term.value!.end_at ?? "").getTime() -
+			(new Date(term.value!.endAt ?? "").getTime() -
 				new Date().getTime()) /
 				1000 /
 				604800 <
@@ -156,7 +154,7 @@ const allOutcomesPast = computed<LearningDomainOutcome[]>(() =>
 	props.submissions
 		.filter(
 			(s) =>
-				new Date(s.submittedAt!) <= new Date(term.value!.start_at ?? "")
+				new Date(s.submittedAt!) <= new Date(term.value!.startAt ?? "")
 		)
 		.flatMap((submission) =>
 			submission.results!.map((result) => result.outcome!)
@@ -168,28 +166,29 @@ const allOutcomesCurrentSemester = computed<LearningDomainOutcome[]>(() =>
 		.filter(
 			(s) =>
 				new Date(s.submittedAt!) >=
-					new Date(term.value!.start_at ?? "") &&
-				new Date(s.submittedAt!) <= new Date(term.value!.end_at ?? "")
+					new Date(term.value!.startAt ?? "") &&
+				new Date(s.submittedAt!) <= new Date(term.value!.endAt ?? "")
 		)
 		.flatMap((submission) =>
 			submission.results!.map((result) => result.outcome!)
 		)
 )
 
-const uniqueOutcomeIds = new Set<number | undefined>();
+const uniqueOutcomeIds = new Set<number | undefined>()
 
 const newMasteredKpis = allOutcomesCurrentSemester?.value.filter((o) => {
-		console.log("O: " + o.id);
-		if (uniqueOutcomeIds.has(o.id)) {
-			return false;
-		}
-		uniqueOutcomeIds.add(o.id);
-		return true;
-	allOutcomesPast.value.filter((x) => x.id == o.id).forEach((x) =>
-	{
-		console.log("X: " + x.id);
-	});
-});
+	console.log("O: " + o.id)
+	if (uniqueOutcomeIds.has(o.id)) {
+		return false
+	}
+	uniqueOutcomeIds.add(o.id)
+	return true
+	allOutcomesPast.value
+		.filter((x) => x.id == o.id)
+		.forEach((x) => {
+			console.log("X: " + x.id)
+		})
+})
 
 const mostUsedDomains = computed<
 	{

--- a/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
+++ b/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
@@ -174,18 +174,16 @@ const allOutcomesCurrentSemester = computed<LearningDomainOutcome[]>(() =>
 		)
 )
 
-const newMasteredKpis = computed<LearningDomainOutcome[]>(
-	() =>
-		allOutcomesCurrentSemester.value
-			?.filter(
-				(o) =>
-					allOutcomesPast.value.filter((x) => x.id === o.id)
-						.length === 0
-			)
-			.filter(
-				(outcome, index, self) =>
-					index === self.findIndex((t) => t.id === outcome.id)
-			)
+const newMasteredKpis = computed<LearningDomainOutcome[]>(() =>
+	allOutcomesCurrentSemester.value
+		?.filter(
+			(o) =>
+				allOutcomesPast.value.filter((x) => x.id === o.id).length === 0
+		)
+		.filter(
+			(outcome, index, self) =>
+				index === self.findIndex((t) => t.id === outcome.id)
+		)
 )
 
 const mostUsedDomains = computed<

--- a/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
+++ b/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
@@ -25,12 +25,7 @@
 							<v-card>
 								<v-card-title>
 									{{
-										allOutcomesCurrentSemester?.filter(
-											(o) =>
-												allOutcomesPast.filter(
-													(x) => x.id === o.id
-												).length === 0
-										).length
+										newMasteredKpis?.length
 									}}
 								</v-card-title>
 								<v-card-text>
@@ -180,6 +175,21 @@ const allOutcomesCurrentSemester = computed<LearningDomainOutcome[]>(() =>
 			submission.results!.map((result) => result.outcome!)
 		)
 )
+
+const uniqueOutcomeIds = new Set<number | undefined>();
+
+const newMasteredKpis = allOutcomesCurrentSemester?.value.filter((o) => {
+		console.log("O: " + o.id);
+		if (uniqueOutcomeIds.has(o.id)) {
+			return false;
+		}
+		uniqueOutcomeIds.add(o.id);
+		return true;
+	allOutcomesPast.value.filter((x) => x.id == o.id).forEach((x) =>
+	{
+		console.log("X: " + x.id);
+	});
+});
 
 const mostUsedDomains = computed<
 	{

--- a/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
+++ b/Epsilon.Host.Frontend/src/components/wrapped/WrappedDialog.vue
@@ -24,23 +24,7 @@
 						<v-col cols="4">
 							<v-card>
 								<v-card-title>
-									{{
-										allOutcomesCurrentSemester
-											?.filter(
-												(o) =>
-													allOutcomesPast.filter(
-														(x) => x.id === o.id
-													).length === 0
-											)
-											.filter(
-												(outcome, index, self) =>
-													index ===
-													self.findIndex(
-														(t) =>
-															t.id === outcome.id
-													)
-											).length
-									}}
+									{{ newMasteredKpis }}
 								</v-card-title>
 								<v-card-text>
 									New KPI's masterd this semester
@@ -189,6 +173,24 @@ const allOutcomesCurrentSemester = computed<LearningDomainOutcome[]>(() =>
 			submission.results!.map((result) => result.outcome!)
 		)
 )
+
+const newMasteredKpis = computed<LearningDomainOutcome[]>(() =>
+	allOutcomesCurrentSemester.value
+		?.filter(
+			(o) =>
+				allOutcomesPast.value.filter(
+					(x) => x.id === o.id
+				).length === 0
+		)
+		.filter(
+			(outcome, index, self) =>
+				index ===
+				self.findIndex(
+					(t) =>
+						t.id === outcome.id
+				)
+		).length
+) 
 
 const mostUsedDomains = computed<
 	{


### PR DESCRIPTION
In this pull request the following tasks have been done:

- api.generated.ts has been regenerated, because the back-end was updated
- Term start and term end is taken from the course in which Epsilon is used
- Fixed new Kpi's Mastered filtering so it only takes the unique new KPI's mastered instead of total times a new KPI is mastered
- Moved new Kpi's mastered filtering into 'newMasteredKpis' method