### PR TITLE
Bugfix: No course term defined. 

### DIFF
--- a/Epsilon/Services/FilterService.cs
+++ b/Epsilon/Services/FilterService.cs
@@ -72,7 +72,7 @@ public class FilterService : IFilterService
         var participatedTerms = response.LegacyNode.Enrollments
                                         .Select(static e => e.Course?.Term!)
                                         .DistinctBy(static t => t?.Id)
-                                        .Where(term => term is { StartAt: not null, EndAt: not null, } && term.StartAt <= currentCourseEnrolment?.Course?.Term?.StartAt)
+                                        .Where(term => term is { StartAt: not null, EndAt: not null, } && term.StartAt <= (currentCourseEnrolment?.Course?.Term?.StartAt ?? DateTime.Now))
                                         .OrderByDescending(static term => term?.StartAt).ToList();
 
 


### PR DESCRIPTION
When no current course term is active, use current time. Aka single out filter.